### PR TITLE
Replace old version of kotlin-logging with the new one on different maven coords and adjusted usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -3,6 +3,7 @@ name: 'Bug report'
 about: 'Report a bug in camunda-platform-7-rest-client-spring-boot'
 title:
 labels: 'Type: bug'
+type: 'Bug'
 assignees: 
 
 ---

--- a/.github/ISSUE_TEMPLATE/2_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.md
@@ -3,6 +3,7 @@ name: 'Feature request'
 about: 'Suggest a feature for camunda-platform-7-rest-client-spring-boot'
 title:
 labels: 'Type: enhancement'
+type: 'Feature'
 assignees: 
 
 ---

--- a/examples/example-feign-client/src/main/kotlin/org/camunda/community/rest/example/feign/process/ProcessDelegatesConfiguration.kt
+++ b/examples/example-feign-client/src/main/kotlin/org/camunda/community/rest/example/feign/process/ProcessDelegatesConfiguration.kt
@@ -23,20 +23,20 @@
 
 package org.camunda.community.rest.example.feign.process
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.delegate.JavaDelegate
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Instant
 import java.util.*
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * Configure delegates for the process service tasks.
  */
 @Configuration
 class ProcessDelegatesConfiguration {
-
-  companion object : KLogging()
 
   /**
    * Logging delegate.

--- a/examples/example-provided/src/main/kotlin/org/camunda/community/rest/example/processapplication/client/ProcessClient.kt
+++ b/examples/example-provided/src/main/kotlin/org/camunda/community/rest/example/processapplication/client/ProcessClient.kt
@@ -23,7 +23,7 @@
 
 package org.camunda.community.rest.example.processapplication.client
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.RuntimeService
 import org.camunda.bpm.engine.variable.Variables.*
@@ -32,6 +32,8 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.scheduling.annotation.Scheduled
 import java.time.Instant
 import java.util.*
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * This client could be a spring component, but is built using configuration
@@ -42,7 +44,7 @@ class ProcessClient(
   @Qualifier("remote") private val repositoryService: RepositoryService
 ) {
 
-  companion object : KLogging() {
+  companion object {
     const val RATE = 5_000L // loop with rate of five seconds
   }
 

--- a/examples/example-provided/src/main/kotlin/org/camunda/community/rest/example/processapplication/process/ProcessDelegatesConfiguration.kt
+++ b/examples/example-provided/src/main/kotlin/org/camunda/community/rest/example/processapplication/process/ProcessDelegatesConfiguration.kt
@@ -23,12 +23,14 @@
 
 package org.camunda.community.rest.example.processapplication.process
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.delegate.JavaDelegate
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Instant
 import java.util.*
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Configure delegates for the process service tasks.
@@ -36,7 +38,6 @@ import java.util.*
 @Configuration
 class ProcessDelegatesConfiguration {
 
-  companion object : KLogging()
 
   /**
    * Logging delegate.

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/config/CamundaHttpExceptionReason.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/config/CamundaHttpExceptionReason.kt
@@ -1,7 +1,9 @@
 package org.camunda.community.rest.config
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * Exception reason.
@@ -17,7 +19,7 @@ internal data class CamundaHttpExceptionReason(
   @JsonProperty("code")
   val code: String?
 ) {
-  companion object : KLogging() {
+  companion object {
     private const val FQCN = "(([a-zA-Z_\$][a-zA-Z\\d_\$]*\\.)*[a-zA-Z_\$][a-zA-Z\\d_\$]*): (.*)"
 
     /**

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/config/FeignErrorDecoderConfiguration.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/config/FeignErrorDecoderConfiguration.kt
@@ -23,12 +23,13 @@
 package org.camunda.community.rest.config
 
 import feign.codec.ErrorDecoder
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.community.rest.exception.RemoteProcessEngineException
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+private val logger = KotlinLogging.logger {}
 
 /**
  * Configures error decoding.
@@ -41,8 +42,6 @@ import org.springframework.context.annotation.Configuration
 class FeignErrorDecoderConfiguration(
   val camundaRestClientProperties: CamundaRestClientProperties
 ) {
-
-  companion object : KLogging()
 
   /**
    * Provides an error decoder bean for feign.

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/Mappers.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/Mappers.kt
@@ -1,6 +1,6 @@
 package org.camunda.community.rest.impl
 
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.task.DelegationState
 import org.camunda.bpm.engine.task.Task
 import org.camunda.community.rest.adapter.IdentityLinkAdapter

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/RemoteTaskService.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/RemoteTaskService.kt
@@ -1,7 +1,7 @@
 package org.camunda.community.rest.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.task.IdentityLink
 import org.camunda.bpm.engine.task.Task
 import org.camunda.bpm.engine.task.TaskQuery
@@ -18,6 +18,8 @@ import org.camunda.community.rest.variables.ValueMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * Remote implementation of Camunda Core TaskService API, delegating
  * all request over HTTP to a remote Camunda Engine.
@@ -30,8 +32,6 @@ class RemoteTaskService(
   objectMapper: ObjectMapper,
   valueTypeResolver: ValueTypeResolver
 ) : AbstractTaskServiceAdapter() {
-
-  companion object : KLogging()
 
   private val valueMapper: ValueMapper = ValueMapper(objectMapper, valueTypeResolver)
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/builder/DelegatingDecisionEvaluationBuilder.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/builder/DelegatingDecisionEvaluationBuilder.kt
@@ -1,10 +1,9 @@
 package org.camunda.community.rest.impl.builder
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.dmn.engine.DmnDecisionResult
 import org.camunda.bpm.engine.BadUserRequestException
-import org.camunda.bpm.engine.ProcessEngine
 import org.camunda.bpm.engine.dmn.DecisionEvaluationBuilder
 import org.camunda.bpm.engine.dmn.DecisionsEvaluationBuilder
 import org.camunda.bpm.engine.exception.NotFoundException
@@ -19,6 +18,8 @@ import org.camunda.community.rest.impl.builder.decision.DelegatingDmnDecisionRul
 import org.camunda.community.rest.impl.builder.decision.DelegatingDmnDecisionTableResult
 import org.camunda.community.rest.variables.ValueMapper
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * Decision evaluation builder, collecting all settings in the DTO sent to the REST endpoint later.
  */
@@ -29,8 +30,6 @@ abstract class AbstractDecisionEvaluationBuilder<T : AbstractDecisionEvaluationB
   private val decisionDefinitionId: String? = null,
   private val decisionDefinitionKey: String? = null
 ) {
-
-  companion object : KLogging()
 
   private val valueMapper: ValueMapper = ValueMapper(objectMapper, valueTypeResolver)
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/builder/DelegatingDeploymentBuilder.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/builder/DelegatingDeploymentBuilder.kt
@@ -1,6 +1,6 @@
 package org.camunda.community.rest.impl.builder
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.ProcessEngineException
 import org.camunda.bpm.engine.repository.Deployment
 import org.camunda.bpm.engine.repository.DeploymentBuilder
@@ -19,6 +19,8 @@ import java.io.*
 import java.util.*
 import java.util.zip.ZipInputStream
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * Deployment builder, collecting all settings in the DTO sent to the REST endpoint later.
  */
@@ -26,7 +28,7 @@ class DelegatingDeploymentBuilder(
   private val deploymentApiClient: DeploymentApiClient
 ) : DeploymentBuilder {
 
-  companion object : KLogging() {
+  companion object {
     val BPMN_RESOURCE_SUFFIXES = arrayOf("bpmn20.xml", "bpmn")
     val DMN_RESOURCE_SUFFIXES = arrayOf("dmn11.xml", "dmn")
     val CMMN_RESOURCE_SUFFIXES = arrayOf("cmmn11.xml", "cmmn10.xml", "cmmn")

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/builder/DelegatingMessageCorrelationBuilder.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/builder/DelegatingMessageCorrelationBuilder.kt
@@ -23,7 +23,7 @@
 
 package org.camunda.community.rest.impl.builder
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder
 import org.camunda.bpm.engine.runtime.MessageCorrelationResult
 import org.camunda.bpm.engine.runtime.MessageCorrelationResultWithVariables
@@ -33,6 +33,8 @@ import org.camunda.community.rest.client.model.CorrelationMessageDto
 import org.camunda.community.rest.variables.ValueMapper
 import org.camunda.community.rest.variables.fromDto
 
+private val logger = KotlinLogging.logger {}
+
 /**
  * Correlation builder, collecting all settings in the DTO sent to the REST endpoint later.
  */
@@ -41,8 +43,6 @@ class DelegatingMessageCorrelationBuilder(
   private val messageApiClient: MessageApiClient,
   private val valueMapper: ValueMapper
 ) : MessageCorrelationBuilder {
-
-  companion object : KLogging()
 
   private val correlationMessageDto: CorrelationMessageDto = CorrelationMessageDto().apply {
     this.messageName = messageName

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/BaseQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/BaseQuery.kt
@@ -1,6 +1,6 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.ProcessEngineException
 import org.camunda.bpm.engine.query.Query
 import org.camunda.bpm.engine.variable.type.ValueType
@@ -15,6 +15,8 @@ import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.full.withNullability
 import kotlin.reflect.jvm.isAccessible
 
+val logger = KotlinLogging.logger {}
+
 /**
  * Base clas for queries delegating to remote calls.
  */
@@ -24,8 +26,6 @@ abstract class BaseQuery<T : Query<*, *>, U>(
   var tenantIds: Array<out String>? = null,
   var tenantIdsSet: Boolean = false,
 ) : Query<T, U> {
-
-  companion object : KLogging()
 
   override fun unlimitedList(): List<U> {
     // FIXME: best approximation so far.
@@ -145,7 +145,7 @@ abstract class BaseQuery<T : Query<*, *>, U>(
    * @return the sorting property
    */
   fun sortProperty(): QueryOrderingProperty? {
-    if (this.orderingProperties.size > 1) BaseQuery.logger.warn { "sorting with more than one property not supported, ignoring all but first" }
+    if (this.orderingProperties.size > 1) logger.warn { "sorting with more than one property not supported, ignoring all but first" }
     return this.orderingProperties.firstOrNull()
   }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingDeploymentQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingDeploymentQuery.kt
@@ -1,6 +1,5 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.repository.Deployment
 import org.camunda.bpm.engine.repository.DeploymentQuery
 import org.camunda.community.rest.adapter.DeploymentAdapter
@@ -22,8 +21,6 @@ class DelegatingDeploymentQuery(
   var deploymentAfter: Date? = null,
   var includeDeploymentsWithoutTenantId: Boolean = false
 ) : BaseQuery<DeploymentQuery, Deployment>(), DeploymentQuery {
-
-  companion object : KLogging()
 
   override fun deploymentId(deploymentId: String?) = this.apply { this.deploymentId = requireNotNull(deploymentId) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingEventSubscriptionQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingEventSubscriptionQuery.kt
@@ -1,6 +1,5 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.runtime.EventSubscription
 import org.camunda.bpm.engine.runtime.EventSubscriptionQuery
 import org.camunda.community.rest.adapter.EventSubscriptionAdapter
@@ -8,7 +7,6 @@ import org.camunda.community.rest.adapter.EventSubscriptionBean
 import org.camunda.community.rest.client.api.EventSubscriptionApiClient
 import org.springframework.web.bind.annotation.RequestParam
 import kotlin.reflect.KParameter
-import kotlin.reflect.full.declaredMemberProperties
 
 class DelegatingEventSubscriptionQuery(
   private val eventSubscriptionApiClient: EventSubscriptionApiClient,
@@ -20,8 +18,6 @@ class DelegatingEventSubscriptionQuery(
   var activityId: String? = null,
   var includeEventSubscriptionsWithoutTenantId: Boolean = false
 ) : BaseQuery<EventSubscriptionQuery, EventSubscription>(), EventSubscriptionQuery {
-
-  companion object : KLogging()
 
   override fun eventSubscriptionId(eventSubscriptionId: String?) = this.apply { this.eventSubscriptionId = requireNotNull(eventSubscriptionId) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingExecutionQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingExecutionQuery.kt
@@ -1,6 +1,6 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.exception.NotValidException
 import org.camunda.bpm.engine.runtime.Execution
 import org.camunda.bpm.engine.runtime.ExecutionQuery
@@ -11,8 +11,6 @@ import org.camunda.community.rest.client.model.ExecutionQueryDto
 import org.camunda.community.rest.impl.toExecutionSorting
 import org.camunda.community.rest.variables.toDto
 import kotlin.reflect.KMutableProperty1
-import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -31,8 +29,6 @@ class DelegatingExecutionQuery(
   var incidentMessageLike: String? = null,
   val eventSubscriptions: MutableList<EventSubscriptionQueryValue> = mutableListOf()
 ) : BaseVariableQuery<ExecutionQuery, Execution>(), ExecutionQuery {
-
-  companion object : KLogging()
 
   override fun processDefinitionKey(processDefinitionKey: String?) = this.apply { this.processDefinitionKey = requireNotNull(processDefinitionKey) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingExternalTaskQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingExternalTaskQuery.kt
@@ -1,6 +1,5 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.externaltask.ExternalTask
 import org.camunda.bpm.engine.externaltask.ExternalTaskQuery
 import org.camunda.community.rest.adapter.ExternalTaskAdapter
@@ -38,8 +37,6 @@ class DelegatingExternalTaskQuery(
   var lockExpirationBefore: Date? = null,
   var lockExpirationAfter: Date? = null,
 ) : BaseQuery<ExternalTaskQuery, ExternalTask>(), ExternalTaskQuery {
-
-  companion object : KLogging()
 
   override fun processInstanceId(processInstanceId: String?) = this.apply { this.processInstanceId = requireNotNull(processInstanceId) }
   override fun processInstanceIdIn(vararg processInstanceIdIn: String) = this.apply { this.processInstanceIds = processInstanceIdIn.toList() }

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingHistoricProcessInstanceQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingHistoricProcessInstanceQuery.kt
@@ -1,6 +1,5 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.BadUserRequestException
 import org.camunda.bpm.engine.history.HistoricProcessInstance
 import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery
@@ -69,8 +68,6 @@ class DelegatingHistoricProcessInstanceQuery(
   var finishDateOnEnd: Date? = null,
   var isOrQueryActive: Boolean = false
 ) : BaseVariableQuery<HistoricProcessInstanceQuery, HistoricProcessInstance>(), HistoricProcessInstanceQuery {
-
-  companion object : KLogging()
 
   override fun processInstanceId(processInstanceId: String?) = this.apply { this.processInstanceId = requireNotNull(processInstanceId) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingIncidentQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingIncidentQuery.kt
@@ -1,6 +1,5 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.runtime.Incident
 import org.camunda.bpm.engine.runtime.IncidentQuery
 import org.camunda.community.rest.adapter.IncidentAdapter
@@ -29,8 +28,6 @@ class DelegatingIncidentQuery(
   var configuration: String? = null,
   var jobDefinitionIds: Array<out String>? = null
 ) : BaseQuery<IncidentQuery, Incident>(), IncidentQuery {
-
-  companion object : KLogging()
 
   override fun incidentId(incidentId: String?) = this.apply { this.id = requireNotNull(incidentId) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingProcessDefinitionQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingProcessDefinitionQuery.kt
@@ -22,7 +22,6 @@
  */
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.ProcessEngineException
 import org.camunda.bpm.engine.impl.ProcessDefinitionQueryImpl
 import org.camunda.bpm.engine.repository.ProcessDefinition
@@ -72,8 +71,6 @@ class DelegatingProcessDefinitionQuery(
   var isNotStartableInTasklist: Boolean = false,
   var startablePermissionCheck: Boolean = false
 ) : BaseQuery<ProcessDefinitionQuery, ProcessDefinition>(), ProcessDefinitionQuery {
-
-  companion object : KLogging()
 
   override fun processDefinitionId(processDefinitionId: String?) = this.apply { this.id = requireNotNull(processDefinitionId) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingProcessInstanceQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingProcessInstanceQuery.kt
@@ -1,6 +1,5 @@
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.ProcessEngineException
 import org.camunda.bpm.engine.runtime.ProcessInstance
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery
@@ -45,8 +44,6 @@ class DelegatingProcessInstanceQuery(
   var isProcessDefinitionWithoutTenantId: Boolean = false,
   var isOrQueryActive: Boolean = false
 ) : BaseVariableQuery<ProcessInstanceQuery, ProcessInstance>(), ProcessInstanceQuery {
-
-  companion object : KLogging()
 
   override fun processInstanceId(processInstanceId: String?) = this.apply { this.processInstanceId = requireNotNull(processInstanceId) }
 

--- a/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingTaskQuery.kt
+++ b/extension/core/src/main/kotlin/org/camunda/community/rest/impl/query/DelegatingTaskQuery.kt
@@ -22,7 +22,6 @@
  */
 package org.camunda.community.rest.impl.query
 
-import mu.KLogging
 import org.camunda.bpm.engine.ProcessEngineException
 import org.camunda.bpm.engine.task.DelegationState
 import org.camunda.bpm.engine.task.Task
@@ -118,8 +117,6 @@ class DelegatingTaskQuery(
   val expressions: MutableMap<String, String> = mutableMapOf(),
   var isOrQueryActive: Boolean = false
 ) : BaseVariableQuery<TaskQuery, Task>(), TaskQuery {
-
-  companion object : KLogging()
 
   override fun taskId(taskId: String?) = this.apply { this.taskId = requireNotNull(taskId) }
 

--- a/extension/starter/src/main/kotlin/org/camunda/community/rest/starter/ProcessEngineClientStubAutoConfiguration.kt
+++ b/extension/starter/src/main/kotlin/org/camunda/community/rest/starter/ProcessEngineClientStubAutoConfiguration.kt
@@ -1,6 +1,6 @@
 package org.camunda.community.rest.starter
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.camunda.bpm.engine.DecisionService
 import org.camunda.bpm.engine.ExternalTaskService
 import org.camunda.bpm.engine.HistoryService
@@ -13,6 +13,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+private val logger = KotlinLogging.logger {}
 /**
  * Auto configuration providing client stub if no process engine is available.
  */
@@ -20,7 +21,7 @@ import org.springframework.context.annotation.Configuration
 @AutoConfigureAfter(name = ["org.camunda.bpm.spring.boot.starter.CamundaBpmAutoConfiguration"])
 class ProcessEngineClientStubAutoConfiguration {
 
-  companion object : KLogging()
+  companion object
 
   /**
    * Sets up a fake engine if no engine is provided.

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <spring-cloud.version>2024.0.0</spring-cloud.version>
 
     <kotlin.version>2.1.10</kotlin.version>
-    <kotlin-logging.version>3.0.5</kotlin-logging.version>
+    <kotlin-logging.version>7.0.4</kotlin-logging.version>
 
     <!-- test tools -->
     <assertj.version>3.27.3</assertj.version>
@@ -122,7 +122,7 @@
   <dependencies>
     <!-- Kotlin -->
     <dependency>
-      <groupId>io.github.microutils</groupId>
+      <groupId>io.github.oshai</groupId>
       <artifactId>kotlin-logging-jvm</artifactId>
       <version>${kotlin-logging.version}</version>
     </dependency>


### PR DESCRIPTION
- old package (`mu.KLogging`) doesn't exist since v.5
- new package is called `io.github.oshai.kotlinlogging`
- instead of companion object extending KLogging the instantiation is now: 
```
// Place definition above class declaration to make field static
private val logger = KotlinLogging.logger {}
```
- check for more details: https://github.com/oshai/kotlin-logging
- update from 3.0.5 to 7.0.4
- fix #594